### PR TITLE
Add entropy logging and visualization to evaluation pipeline

### DIFF
--- a/evaluation/infer.py
+++ b/evaluation/infer.py
@@ -53,6 +53,8 @@ def parse_arguments():
                                   help="Repetition penalty factor")
     generation_group.add_argument("--include_stop_str_in_output", type=bool, default=True,
                                   help="Whether to include stop strings in output")
+    generation_group.add_argument("--entropy_top_k", type=int, default=5,
+                                  help="Number of top token log-probabilities used to estimate entropy")
 
     inference_group = parser.add_argument_group("Inference Configuration")
     inference_group.add_argument("--max_concurrent_requests", type=int, default=50,

--- a/evaluation/src/entropy_utils.py
+++ b/evaluation/src/entropy_utils.py
@@ -1,0 +1,361 @@
+import json
+import math
+import os
+from typing import Any, Dict, List, Optional
+
+MODULE_TAGS = ["think", "python", "result", "answer"]
+
+
+def _as_dict(obj: Any) -> Dict[str, float]:
+    if obj is None:
+        return {}
+    if isinstance(obj, dict):
+        return {str(k): float(v) for k, v in obj.items() if v is not None}
+    if hasattr(obj, "items"):
+        return {str(k): float(v) for k, v in obj.items() if v is not None}
+    return {}
+
+
+def _get_attr(obj: Any, key: str, default: Any = None) -> Any:
+    if obj is None:
+        return default
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+def compute_entropy_from_top_logprobs(
+    top_logprob_entry: Dict[str, float]
+) -> Optional[float]:
+    if not top_logprob_entry:
+        return None
+    values = list(top_logprob_entry.values())
+    if not values:
+        return None
+    max_logprob = max(values)
+    exp_values = [math.exp(v - max_logprob) for v in values]
+    total = sum(exp_values)
+    if total <= 0:
+        return None
+    probs = [v / total for v in exp_values]
+    entropy = -sum(p * math.log(p) for p in probs if p > 0)
+    return float(entropy)
+
+
+def extract_token_stats_from_choice(choice: Any) -> Dict[str, Any]:
+    logprobs = getattr(choice, "logprobs", None)
+    tokens = _get_attr(logprobs, "tokens", []) or []
+    token_logprobs = _get_attr(logprobs, "token_logprobs", []) or []
+    top_logprobs_raw = _get_attr(logprobs, "top_logprobs", []) or []
+
+    top_logprobs: List[Dict[str, float]] = []
+    entropies: List[Optional[float]] = []
+    for entry in top_logprobs_raw:
+        top_dict = _as_dict(entry)
+        top_logprobs.append(top_dict)
+        entropies.append(compute_entropy_from_top_logprobs(top_dict))
+
+    length = min(len(tokens), len(token_logprobs), len(top_logprobs), len(entropies))
+    tokens = [str(tok) for tok in tokens[:length]]
+    token_logprobs = [
+        (float(lp) if lp is not None else None) for lp in token_logprobs[:length]
+    ]
+    top_logprobs = top_logprobs[:length]
+    entropies = entropies[:length]
+
+    return {
+        "tokens": tokens,
+        "token_logprobs": token_logprobs,
+        "top_logprobs": top_logprobs,
+        "entropies": entropies,
+        "text": getattr(choice, "text", ""),
+    }
+
+
+def trim_token_stats_to_match_text(
+    record: Dict[str, Any], target_text: str
+) -> Dict[str, Any]:
+    if not record:
+        return record
+    if not target_text:
+        return {
+            **record,
+            "tokens": [],
+            "entropies": [],
+            "token_logprobs": [],
+            "top_logprobs": [],
+            "text": target_text,
+        }
+    tokens: List[str] = record.get("tokens", [])
+    entropies: List[Optional[float]] = record.get("entropies", [])
+    token_logprobs: List[Optional[float]] = record.get("token_logprobs", [])
+    top_logprobs: List[Dict[str, float]] = record.get("top_logprobs", [])
+
+    if not tokens:
+        return {**record, "text": target_text}
+
+    trimmed_tokens: List[str] = []
+    trimmed_entropies: List[Optional[float]] = []
+    trimmed_logprobs: List[Optional[float]] = []
+    trimmed_top_logprobs: List[Dict[str, float]] = []
+
+    current_text = ""
+    for token, entropy, logprob, top in zip(
+        tokens, entropies, token_logprobs, top_logprobs
+    ):
+        candidate = current_text + token
+        if target_text and not target_text.startswith(candidate):
+            break
+        trimmed_tokens.append(token)
+        trimmed_entropies.append(entropy)
+        trimmed_logprobs.append(logprob)
+        trimmed_top_logprobs.append(top)
+        current_text = candidate
+        if current_text == target_text:
+            break
+
+    if target_text and "".join(trimmed_tokens) != target_text:
+        return {
+            **record,
+            "tokens": [],
+            "entropies": [],
+            "token_logprobs": [],
+            "top_logprobs": [],
+            "text": target_text,
+        }
+
+    return {
+        "tokens": trimmed_tokens,
+        "entropies": trimmed_entropies,
+        "token_logprobs": trimmed_logprobs,
+        "top_logprobs": trimmed_top_logprobs,
+        "text": target_text,
+    }
+
+
+def _token_char_bounds(tokens: List[str]) -> List[Dict[str, int]]:
+    bounds: List[Dict[str, int]] = []
+    current = 0
+    for token in tokens:
+        start = current
+        current += len(token)
+        bounds.append({"start": start, "end": current})
+    return bounds
+
+
+def _char_to_token_start(bounds: List[Dict[str, int]], char_pos: int) -> int:
+    for idx, bound in enumerate(bounds):
+        if char_pos < bound["end"]:
+            return idx
+    return max(len(bounds) - 1, 0) if bounds else 0
+
+
+def _char_to_token_end(bounds: List[Dict[str, int]], char_pos: int) -> int:
+    for idx, bound in enumerate(bounds):
+        if char_pos <= bound["start"]:
+            return idx
+    return len(bounds)
+
+
+def compute_module_segments(text: str, tokens: List[str]) -> List[Dict[str, Any]]:
+    if not text:
+        return []
+    bounds = _token_char_bounds(tokens)
+    segments: List[Dict[str, Any]] = []
+    for tag in MODULE_TAGS:
+        open_tag = f"<{tag}>"
+        close_tag = f"</{tag}>"
+        search_start = 0
+        while True:
+            start_idx = text.find(open_tag, search_start)
+            if start_idx == -1:
+                break
+            end_idx = text.find(close_tag, start_idx + len(open_tag))
+            if end_idx == -1:
+                break
+            end_idx += len(close_tag)
+            start_token = _char_to_token_start(bounds, start_idx)
+            end_token = _char_to_token_end(bounds, end_idx)
+            segments.append(
+                {
+                    "tag": tag,
+                    "start_char": start_idx,
+                    "end_char": end_idx,
+                    "start_token": start_token,
+                    "end_token": end_token,
+                }
+            )
+            search_start = end_idx
+    segments.sort(key=lambda item: item["start_char"])
+    return segments
+
+
+def aggregate_token_records(
+    records: List[Dict[str, Any]]
+) -> Optional[Dict[str, Any]]:
+    if not records:
+        return None
+    tokens: List[str] = []
+    entropies: List[Optional[float]] = []
+    token_logprobs: List[Optional[float]] = []
+    top_logprobs: List[Dict[str, float]] = []
+    texts: List[str] = []
+    for record in records:
+        if not record:
+            continue
+        record_tokens = record.get("tokens", []) or []
+        record_entropies = record.get("entropies", []) or []
+        record_logprobs = record.get("token_logprobs", []) or []
+        record_top = record.get("top_logprobs", []) or []
+        length = min(
+            len(record_tokens), len(record_entropies), len(record_logprobs), len(record_top)
+        )
+        tokens.extend(record_tokens[:length])
+        entropies.extend(record_entropies[:length])
+        token_logprobs.extend(record_logprobs[:length])
+        top_logprobs.extend(record_top[:length])
+        texts.append(record.get("text", ""))
+
+    full_text = "".join(texts)
+    token_text = "".join(tokens)
+    modules = (
+        compute_module_segments(full_text, tokens)
+        if full_text and token_text and len(token_text) == len(full_text)
+        else []
+    )
+    return {
+        "tokens": tokens,
+        "entropies": entropies,
+        "token_logprobs": token_logprobs,
+        "top_logprobs": top_logprobs,
+        "text": full_text,
+        "modules": modules,
+    }
+
+
+def save_entropy_plot(
+    tokens: List[str],
+    entropies: List[Optional[float]],
+    modules: List[Dict[str, Any]],
+    output_file: str,
+) -> None:
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError:
+        return
+
+    if not entropies:
+        return
+
+    xs = list(range(len(entropies)))
+    y_values = [float("nan") if e is None else float(e) for e in entropies]
+    if all(math.isnan(v) for v in y_values):
+        return
+
+    fig_width = max(8, len(entropies) * 0.2)
+    fig, ax = plt.subplots(figsize=(fig_width, 4.5))
+    ax.plot(xs, y_values, color="#1f77b4", linewidth=1.5, marker="o", markersize=2)
+
+    colors = {
+        "think": "#6baed6",
+        "python": "#fd8d3c",
+        "result": "#74c476",
+        "answer": "#ef3b2c",
+    }
+
+    finite_values = [v for v in y_values if not math.isnan(v)]
+    if finite_values:
+        min_val = min(finite_values)
+        max_val = max(finite_values)
+    else:
+        min_val = 0.0
+        max_val = 1.0
+    value_span = max(max_val - min_val, 1e-6)
+    padding = 0.15 * value_span
+
+    legend_used = set()
+    for segment in modules:
+        tag = segment.get("tag", "")
+        start_token = segment.get("start_token", 0)
+        end_token = segment.get("end_token", start_token)
+        color = colors.get(tag, "#9e9ac8")
+        label = f"<{tag}>" if tag and tag not in legend_used else None
+        ax.axvspan(start_token, end_token, color=color, alpha=0.18, label=label)
+        if label:
+            legend_used.add(tag)
+    if legend_used:
+        ax.legend(loc="upper right")
+
+    text_y = max_val + padding
+    for segment in modules:
+        tag = segment.get("tag", "")
+        if not tag:
+            continue
+        start_token = segment.get("start_token", 0)
+        end_token = segment.get("end_token", start_token)
+        center = (start_token + end_token) / 2 if end_token != start_token else start_token
+        color = colors.get(tag, "#555555")
+        ax.text(
+            center,
+            text_y,
+            f"<{tag}>",
+            ha="center",
+            va="bottom",
+            fontsize=8,
+            fontweight="bold",
+            color=color,
+        )
+
+    ax.set_xlabel("Token Index")
+    ax.set_ylabel("Entropy (nats)")
+    ax.set_title("Token-level Entropy Trajectory")
+    ax.set_xlim(0, max(xs) if xs else 1)
+    ax.set_ylim(min_val - padding, text_y + padding)
+    ax.grid(True, linestyle="--", alpha=0.3)
+    fig.tight_layout()
+    os.makedirs(os.path.dirname(output_file), exist_ok=True)
+    fig.savefig(output_file, dpi=200)
+    plt.close(fig)
+
+
+def save_sample_artifacts(
+    sample_stat: Dict[str, Any], sample_dir: str, sample_index: int
+) -> None:
+    os.makedirs(sample_dir, exist_ok=True)
+    trajectory_path = os.path.join(sample_dir, "trajectory.txt")
+    metadata_path = os.path.join(sample_dir, "metadata.json")
+    token_trace_path = os.path.join(sample_dir, "token_trace.json")
+    plot_path = os.path.join(sample_dir, "token_entropy.png")
+
+    with open(trajectory_path, "w", encoding="utf-8") as f:
+        f.write(f"Sample Index: {sample_index}\n")
+        f.write(f"Instruction: {sample_stat.get('instruction', '')}\n")
+        f.write(f"Question: {sample_stat.get('input', '')}\n")
+        f.write(f"Golden Answer: {sample_stat.get('answer', '')}\n")
+        f.write(f"Prediction: {sample_stat.get('prediction', '')}\n\n")
+        f.write("Full Output:\n")
+        f.write(sample_stat.get("output", ""))
+        f.write("\n\n-- Logs --\n")
+        for log in sample_stat.get("logs", []):
+            f.write(f"{log}\n")
+
+    metadata = {
+        "sample_index": sample_index,
+        "question": sample_stat.get("input"),
+        "golden_answer": sample_stat.get("answer"),
+        "prediction": sample_stat.get("prediction"),
+        "timing": sample_stat.get("timing"),
+    }
+    with open(metadata_path, "w", encoding="utf-8") as f:
+        json.dump(metadata, f, indent=2, ensure_ascii=False)
+
+    token_trace = sample_stat.get("token_trace")
+    if token_trace:
+        with open(token_trace_path, "w", encoding="utf-8") as f:
+            json.dump(token_trace, f, indent=2, ensure_ascii=False)
+        save_entropy_plot(
+            token_trace.get("tokens", []),
+            token_trace.get("entropies", []),
+            token_trace.get("modules", []),
+            plot_path,
+        )

--- a/evaluation/src/inference_engine.py
+++ b/evaluation/src/inference_engine.py
@@ -14,6 +14,7 @@ from .tools.tool_executor import ToolExecutor
 from .tools import PythonTool, BingSearchTool, BingSearchToolSDS
 from .vllm_client_pool import VLLMClientPool
 from .sample_processor import SampleProcessor, SampleProcessorCompletion
+from .entropy_utils import save_sample_artifacts
 
 
 class AsyncInference:
@@ -43,6 +44,7 @@ class AsyncInference:
             repetition_penalty=args.repetition_penalty,
             n=1,
             include_stop_str_in_output=args.include_stop_str_in_output,
+            logprobs=getattr(args, "entropy_top_k", 5),
         )
         self.args.sampling_params_nostop = SamplingParams(
             temperature=args.temperature,
@@ -54,6 +56,7 @@ class AsyncInference:
             n=1,
             include_stop_str_in_output=args.include_stop_str_in_output,
             stop=None,
+            logprobs=getattr(args, "entropy_top_k", 5),
         )
         self.sample_timeout = getattr(args, "sample_timeout", 240)
         print(f"Initialized {self.__class__.__name__}...")
@@ -234,6 +237,7 @@ class AsyncInference:
                 print(
                     f"Processed {dataset_name} (Turn {turn}), save results to {output_file}"
                 )
+                self._save_turn_artifacts(dataset_name, turn, results)
         print("Finished to process all datasets!")
 
 
@@ -250,6 +254,20 @@ class AsyncInferenceCompletion(AsyncInference):
             session_id,
         )
         return processor
+
+    def _save_turn_artifacts(self, dataset_name: str, turn: int, results):
+        if not self.args.output_path:
+            return
+        turn_dir = os.path.join(
+            self.args.output_path,
+            dataset_name,
+            f"turn_{turn}_samples",
+        )
+        for idx, sample in enumerate(results):
+            if not sample:
+                continue
+            sample_dir = os.path.join(turn_dir, f"sample_{idx:04d}")
+            save_sample_artifacts(sample, sample_dir, idx)
 
 
 class AsyncInferenceCompletionSDS(AsyncInferenceCompletion):

--- a/evaluation/src/sample_processor.py
+++ b/evaluation/src/sample_processor.py
@@ -1,6 +1,11 @@
 import time
 import hashlib
 from .utils import extract_answer
+from .entropy_utils import (
+    aggregate_token_records,
+    extract_token_stats_from_choice,
+    trim_token_stats_to_match_text,
+)
 
 
 class SampleProcessor:
@@ -36,6 +41,7 @@ class SampleProcessor:
         self.python_rounds = 0
         self.search_rounds = 0
         self.in_context = ""
+        self.token_records = []
         self.messages = [
             {"role": "system", "content": system_prompt},
             {"role": "user", "content": question},
@@ -71,7 +77,9 @@ class SampleProcessor:
             if not result:
                 print("The LLM fails to generate output!\n")
                 return 'None' if not all_output else all_output
-            output = result.choices[0].text
+            choice = result.choices[0]
+            token_stats = extract_token_stats_from_choice(choice)
+            output = choice.text
             output = output.split("<result>")[0]
             if "</search>" in output:
                 output = output.split("</search>")[0] + "</search>"
@@ -79,6 +87,8 @@ class SampleProcessor:
                 output = output.split("</python>")[0] + "</python>"
             if "</answer>" in output:
                 output = output.split("</answer>")[0] + "</answer>"
+            trimmed_stats = trim_token_stats_to_match_text(token_stats, output)
+            self._record_token_stats(trimmed_stats)
             all_output += output
             if (
                 "</search>" not in all_output
@@ -154,6 +164,7 @@ class SampleProcessor:
 
         self.sample_stat["prediction"] = extract_answer(self.sample_stat["output"])
         self.total_time = time.time() - self.sample_start_time
+        self._finalize_token_trace()
 
     def log_timing(self):
         print(f"Time consumption for question: {self.question[:30]}...")
@@ -167,6 +178,16 @@ class SampleProcessor:
             "search_time": self.search_time,
             "total_time": self.total_time,
         }
+
+    def _record_token_stats(self, record):
+        if not record:
+            return
+        self.token_records.append(record)
+
+    def _finalize_token_trace(self):
+        token_trace = aggregate_token_records(self.token_records)
+        if token_trace:
+            self.sample_stat["token_trace"] = token_trace
 
 
 class SampleProcessorCompletion(SampleProcessor):
@@ -223,3 +244,4 @@ class SampleProcessorCompletion(SampleProcessor):
                 break
         self.sample_stat["prediction"] = extract_answer(self.sample_stat["output"])
         self.total_time = time.time() - self.sample_start_time
+        self._finalize_token_trace()

--- a/evaluation/src/vllm_client_pool.py
+++ b/evaluation/src/vllm_client_pool.py
@@ -58,6 +58,7 @@ class VLLMClientPool:
             "stop": sampling_params.stop,
             "repetition_penalty": sampling_params.repetition_penalty,
             "include_stop_str_in_output": sampling_params.include_stop_str_in_output,
+            "logprobs": getattr(sampling_params, "logprobs", None),
         }
         client = await self.get_client_for_session(session_id)
         for attempt in range(3): 
@@ -69,6 +70,7 @@ class VLLMClientPool:
                     top_p=params.get("top_p", 0.7),
                     max_tokens=params.get("max_tokens", 8192),
                     stop=params.get("stop", ["</python>", "</search>", "</answer>"]),
+                    logprobs=params.get("logprobs"),
                     extra_body={
                         "repetition_penalty": params.get("repetition_penalty", 1.05),
                         "include_stop_str_in_output": params.get("include_stop_str_in_output", True),
@@ -102,6 +104,7 @@ class VLLMClientPool:
                     top_p=params.get("top_p", 0.7),
                     max_tokens=params.get("max_tokens", 8192),
                     stop=params.get("stop", ["</python>", "</search>", "</answer>"]),
+                    logprobs=params.get("logprobs"),
                     extra_body={
                         "repetition_penalty": params.get("repetition_penalty", 1.05),
                         "include_stop_str_in_output": params.get("include_stop_str_in_output", True),


### PR DESCRIPTION
## Summary
- add entropy_utils helpers to compute token-level entropies, segment outputs, and persist per-sample artifacts with plots and metadata
- record generation token statistics during inference, attach traces to results, and export per-sample folders with trajectory files and entropy charts
- request log-probabilities during vLLM generation and expose an entropy_top_k CLI option to control entropy estimation granularity

## Testing
- python -m compileall evaluation/src

------
https://chatgpt.com/codex/tasks/task_e_68edfa23bb2c8330abdb7a7994b265b2